### PR TITLE
Added signal definition using workflow parameters

### DIFF
--- a/includes/CCPiEvent.h
+++ b/includes/CCPiEvent.h
@@ -29,12 +29,13 @@ class Variable;
 
 struct CCPiEvent {
   CCPiEvent(const bool is_mc, const bool is_truth,
-            const SignalDefinition signal_definition, CVUniverse* universe);
+            const SignalDefinition signal_definition, CVUniverse* universe, std::vector<double> params);
 
   // Fixed by the constructor
   const bool m_is_mc;
   const bool m_is_truth;
   const SignalDefinition m_signal_definition;
+  const std::vector<double> m_params;
   CVUniverse* m_universe;
   std::vector<RecoPionIdx>
       m_reco_pion_candidate_idxs;  // initialized empty, filled by PassesCuts

--- a/includes/CVUniverse.cxx
+++ b/includes/CVUniverse.cxx
@@ -577,10 +577,10 @@ double CVUniverse::GetCalRecoilEnergy_DefaultSpline() const {
 
 // This is what the response universe calls our tracked recoil energy
 double CVUniverse::GetNonCalRecoilEnergy() const {
-#ifdef NDEBUG
-  if (GetPionCandidates().empty())
-    std::cout << "CVU::GetETrackedRecoilEnergy WARNING: no pion candidates!\n";
-#endif
+//#ifdef NDEBUG
+//  if (GetPionCandidates().empty())
+//    std::cout << "CVU::GetETrackedRecoilEnergy WARNING: no pion candidates!\n";
+//#endif
 
   double etracks = 0.;
 

--- a/includes/Cuts.h
+++ b/includes/Cuts.h
@@ -30,24 +30,24 @@
 //==============================================================================
 // Call the cut functions -- fill-in/return the ref to the good pion candidate
 bool PassesCuts(CVUniverse&, std::vector<int>& pion_candidate_idxs, bool is_mc,
-                SignalDefinition, std::vector<ECuts> cuts = kCutsVector);
+                SignalDefinition, std::vector<double> params, std::vector<ECuts> cuts = kCutsVector);
 
 // also tell whether we are w sideband
 bool PassesCuts(CVUniverse&, std::vector<int>& pion_candidate_idxs,
-                const bool is_mc, const SignalDefinition, bool& is_w_sideband,
+                const bool is_mc, const SignalDefinition, bool& is_w_sideband, std::vector<double> params,
                 std::vector<ECuts> cuts = kCutsVector);
 
 // NEW return passes_all_cuts, is_w_sideband, and pion_candidate_indices
 std::tuple<bool, bool, std::vector<int>> PassesCuts(
-    CVUniverse&, const bool is_mc, const SignalDefinition,
+    CVUniverse&, const bool is_mc, const SignalDefinition, std::vector<double> params,
     const std::vector<ECuts> cuts = kCutsVector);
 
 EventCount PassedCuts(const CVUniverse&, std::vector<int>& pion_candidate_idxs,
-                      bool is_mc, SignalDefinition,
+                      bool is_mc, SignalDefinition, std::vector<double> params,
                       std::vector<ECuts> cuts = kCutsVector);
 
 bool PassesCut(const CVUniverse&, const ECuts cut, const bool is_mc,
-               const SignalDefinition, MichelMap& endpoint_michels,
+               const SignalDefinition, std::vector<double> params, MichelMap& endpoint_michels,
                MichelMap& vertex_michels);
 
 // Get a vector of integers which are unique hadron prong identifiers.
@@ -66,7 +66,7 @@ bool MinosActivityCut(const CVUniverse&);
 // Cut functions -- eventwide
 bool MinosMatchCut(const CVUniverse&);
 bool MinosChargeCut(const CVUniverse&);
-bool WexpCut(const CVUniverse&, SignalDefinition);
+bool WexpCut(const CVUniverse&, SignalDefinition, std::vector<double> params);
 bool IsoProngCut(const CVUniverse&);
 std::vector<int> GetQualityPionCandidateIndices(const CVUniverse&);
 bool HadronQualityCuts(const CVUniverse&, const RecoPionIdx pion_candidate_idx);

--- a/includes/MacroUtil.cxx
+++ b/includes/MacroUtil.cxx
@@ -7,6 +7,7 @@
 
 // CTOR Data
 CCPi::MacroUtil::MacroUtil(const int signal_definition,
+                           std::vector<double> params,
                            const std::string& data_file_list,
                            const std::string& plist, const bool is_grid)
     : PlotUtils::MacroUtil("MasterAnaDev", data_file_list, plist),
@@ -14,12 +15,14 @@ CCPi::MacroUtil::MacroUtil(const int signal_definition,
       m_do_mc(false),
       m_do_truth(false),
       m_do_systematics(false),
+      m_params(params),
       m_is_grid(is_grid) {
   Init(signal_definition);
 }
 
 // CTOR MC (and Truth)
 CCPi::MacroUtil::MacroUtil(const int signal_definition,
+                           std::vector<double> params,
                            const std::string& mc_file_list,
                            const std::string& plist, const bool do_truth,
                            const bool is_grid, const bool do_systematics)
@@ -28,12 +31,14 @@ CCPi::MacroUtil::MacroUtil(const int signal_definition,
       m_do_mc(true),
       m_do_truth(do_truth),
       m_do_systematics(do_systematics),
+      m_params(params),
       m_is_grid(is_grid) {
   Init(signal_definition);
 }
 
 // CTOR Data, MC (and Truth)
 CCPi::MacroUtil::MacroUtil(const int signal_definition,
+                           std::vector<double> params,
                            const std::string& mc_file_list,
                            const std::string& data_file_list,
                            const std::string& plist, const bool do_truth,
@@ -44,6 +49,7 @@ CCPi::MacroUtil::MacroUtil(const int signal_definition,
       m_do_mc(true),
       m_do_truth(do_truth),
       m_do_systematics(do_systematics),
+      m_params(params),
       m_is_grid(is_grid) {
   Init(signal_definition);
 }

--- a/includes/MacroUtil.h
+++ b/includes/MacroUtil.h
@@ -19,16 +19,16 @@ namespace CCPi {
 class MacroUtil : public PlotUtils::MacroUtil {
  public:
   // Data
-  MacroUtil(const int signal_definition, const std::string& data_file_list,
+  MacroUtil(const int signal_definition, std::vector<double> params, const std::string& data_file_list,
             const std::string& plist, const bool is_grid);
 
   // MC (and Truth)
-  MacroUtil(const int signal_definition, const std::string& mc_file_list,
+  MacroUtil(const int signal_definition, std::vector<double> params, const std::string& mc_file_list,
             const std::string& plist, const bool do_truth, const bool is_grid,
             const bool do_systematics);
 
   // Data, MC (and Truth)
-  MacroUtil(const int signal_definition, const std::string& mc_file_list,
+  MacroUtil(const int signal_definition, std::vector<double> params, const std::string& mc_file_list,
             const std::string& data_file_list, const std::string& plist,
             const bool do_truth, const bool is_grid, const bool do_systematics);
 
@@ -38,6 +38,7 @@ class MacroUtil : public PlotUtils::MacroUtil {
   bool m_do_systematics;
   bool m_is_grid;
   SignalDefinition m_signal_definition;
+  std::vector<double> m_params;
   CVUniverse* m_data_universe;
   UniverseMap m_error_bands;
   UniverseMap m_error_bands_truth;

--- a/includes/TruthCategories/Coherent.h
+++ b/includes/TruthCategories/Coherent.h
@@ -15,8 +15,8 @@ enum CoherentType
 //==============================================================================
 
 CoherentType GetCoherentType(const CVUniverse& universe,
-                             SignalDefinition signal_definition = kOnePi) {
-  bool is_signal   = GetSignalBackgroundType(universe, signal_definition) == kS;
+                             SignalDefinition signal_definition, std::vector<double> params) {
+  bool is_signal   = GetSignalBackgroundType(universe, signal_definition, params) == kS;
   bool is_coherent = GetChannelType(universe) == kCOHPI;
   if (is_signal)
     return is_coherent ? kCOHERENT_S : kNOTCOHERENT_S;

--- a/includes/TruthCategories/Sidebands.h
+++ b/includes/TruthCategories/Sidebands.h
@@ -25,14 +25,14 @@ enum WSidebandType
 // This is separate from the question of whether we float or fix each category.
 // For that question, see the implementation of the fitter.
 WSidebandType GetWSidebandType(const CVUniverse& universe, 
-                               const SignalDefinition signal_definition, 
+                               const SignalDefinition signal_definition, std::vector<double> params, 
                                const int n_categories = 3) {
   if (n_categories != 2 && n_categories != 3)
     throw std::invalid_argument("GetWSidebandType: n_categories is 2 or 3");
 
   double Wexp_true = universe.GetWexpTrue();
 
-  if (IsSignal(universe, signal_definition))
+  if (IsSignal(universe, signal_definition, params))
     return kWSideband_Signal;
   else {
     if (Wexp_true > 1800)
@@ -91,9 +91,9 @@ enum Pi0SidebandType
 };
 
 Pi0SidebandType GetPi0SidebandType(const CVUniverse& universe, 
-                                   const SignalDefinition signal_definition) {
+                                   const SignalDefinition signal_definition, std::vector<double> params) {
   int n_pi0 = universe.GetInt("truth_N_pi0");
-  if (IsSignal(universe, signal_definition)) return kPi0Sideband_Signal;
+  if (IsSignal(universe, signal_definition, params)) return kPi0Sideband_Signal;
   else if (n_pi0 > 0) return kPi0Sideband_Pi0;
   else return kPi0Sideband_Other;
 }

--- a/includes/TruthCategories/SignalBackground.h
+++ b/includes/TruthCategories/SignalBackground.h
@@ -24,8 +24,8 @@ enum MesonBackgroundType
 // Simple Signal-Background (no BG breakdown)
 //==============================================================================
 SignalBackgroundType GetSignalBackgroundType(const CVUniverse& universe,
-                                             SignalDefinition signal_definition) {
-  if (IsSignal(universe, signal_definition))
+                                             SignalDefinition signal_definition, std::vector<double> params) {
+  if (IsSignal(universe, signal_definition, params))
     return kS;
   else 
     return kB;
@@ -58,10 +58,10 @@ std::string GetTruthClassification_Name(SignalBackgroundType category) {
 // Signal-Background -- W
 //==============================================================================
 WBackgroundType GetWBackgroundType(const CVUniverse& universe,
-                                   SignalDefinition signal_definition) {
-  if (IsSignal(universe, signal_definition))
+                                   SignalDefinition signal_definition, std::vector<double> params) {
+  if (IsSignal(universe, signal_definition, params))
     return kS_W;
-  else if ( GetTruthWType(universe, signal_definition) == kHighW ) {
+  else if ( GetTruthWType(universe, signal_definition, params) == kHighW ) {
     if (universe.GetInt("truth_N_pip") > 1) {
       //if (universe.shortName() == "cv") {
       //  int link_size = 200;
@@ -114,8 +114,8 @@ std::string GetTruthClassification_Name(WBackgroundType category) {
 // Signal-Background -- Meson content
 //==============================================================================
 MesonBackgroundType GetMesonBackgroundType(const CVUniverse& universe,
-                                           SignalDefinition signal_definition) {
-  if (IsSignal(universe, signal_definition))
+                                           SignalDefinition signal_definition, std::vector<double> params) {
+  if (IsSignal(universe, signal_definition, params))
     return kS_Meson;
 
   std::vector<int> fs_particles = universe.GetVec<int>("mc_FSPartPDG");

--- a/includes/TruthCategories/W.h
+++ b/includes/TruthCategories/W.h
@@ -9,12 +9,12 @@ enum WType
   kHighW, kLowW, kNWTypes
 };
 
-WType GetTruthWType(const CVUniverse& universe, SignalDefinition signal_definition) {
+WType GetTruthWType(const CVUniverse& universe, SignalDefinition signal_definition, std::vector<double> params) {
   //=======================================================
   // The actual return value
   //=======================================================
   double Wexp_true = universe.GetWexpTrue();
-  return Wexp_true < GetWCutValue(signal_definition) ? kLowW : kHighW;
+  return Wexp_true < GetWCutValue(signal_definition, params) ? kLowW : kHighW;
 }
 
 std::string GetTruthClassification_LegendLabel(WType w_category){

--- a/studies/runCutVariables.C
+++ b/studies/runCutVariables.C
@@ -73,6 +73,7 @@ std::vector<Variable*> GetCutVariables(
   std::vector<Variable*> variables;
   switch (signal_definition) {
     case kOnePi:
+    case kParams:
       variables = run_cut_variables::GetOnePiVariables(include_truth_vars);
       break;
     default:
@@ -99,7 +100,7 @@ void LoopAndFillCutVars(const CCPi::MacroUtil& util, CVUniverse* universe,
   //for(Long64_t i_event=0; i_event < 10000; ++i_event){
     if (i_event%500000==0) std::cout << (i_event/1000) << "k " << std::endl;
     universe->SetEntry(i_event);
-    CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
+    CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe, util.m_params);
     ccpi_event::FillCutVars(event, variables); // this function does a lot of work
   } // events
   std::cout << "*** Done ***\n\n";
@@ -112,12 +113,14 @@ void LoopAndFillCutVars(const CCPi::MacroUtil& util, CVUniverse* universe,
 void runCutVariables(int signal_definition_int = 0, 
                      const char* plist = "ME1A",
                      std::string data_file_list = "",
-                     std::string mc_file_list = "") {
-
+                     std::string mc_file_list = "",
+                     double w_exp = 1400., double npi = 1, double pim = 0, double pi0 = 0) {
+  // Initialize params tuple
+  std::vector<double> params{ w_exp, npi, pim, pi0 };
   // Macro Utility
   const std::string macro("runCutVariables");
   bool do_truth = false, is_grid = false, do_systematics = false;
-  CCPi::MacroUtil util(signal_definition_int, mc_file_list, data_file_list,
+  CCPi::MacroUtil util(signal_definition_int, params, mc_file_list, data_file_list,
                        plist, do_truth, is_grid, do_systematics);
   util.PrintMacroConfiguration(macro);
 

--- a/xsec/crossSectionDataFromFile.C
+++ b/xsec/crossSectionDataFromFile.C
@@ -34,11 +34,11 @@ void LoopAndFillData(const CCPi::MacroUtil& util,
     util.m_data_universe->SetEntry(i_event);
 
     CCPiEvent event(is_mc, is_truth, util.m_signal_definition,
-                    util.m_data_universe);
+                    util.m_data_universe, util.m_params);
 
     event.m_passes_cuts =
         PassesCuts(*util.m_data_universe, event.m_reco_pion_candidate_idxs,
-                   is_mc, util.m_signal_definition, event.m_is_w_sideband);
+                   is_mc, util.m_signal_definition, event.m_is_w_sideband, util.m_params);
 
     event.m_highest_energy_pion_idx = GetHighestEnergyPionCandidateIndex(event);
     // event.m_is_w_sideband = IsWSideband(event);
@@ -191,11 +191,14 @@ void ScaleBG(Variable* var, CCPi::MacroUtil& util, const CVHW& loW_wgt,
 // Main
 //==============================================================================
 void crossSectionDataFromFile(int signal_definition_int = 0,
-                              const char* plist = "ALL", std::string histograms = "MCXSecInputs.root", std::string xsec_inputs = "DataXSecInputs.root", std::string data_file_list = "data_list.txt", std::string mc_file_list = "mc_list.txt") {
+                              const char* plist = "ALL", std::string histograms = "MCXSecInputs.root", std::string xsec_inputs = "DataXSecInputs.root",
+                              std::string data_file_list = "data_list.txt", std::string mc_file_list = "mc_list.txt",
+                             double w_exp = 1400., double npi = 1, double pim = 0, double pi0 = 0) {
   //============================================================================
   // Setup
   //============================================================================
-
+  // Initialize params tuple
+  std::vector<double> params{ w_exp, npi, pim, pi0 };
   // I/O
   TFile fin(histograms.c_str(), "READ");
   std::cout << "Reading input from " << fin.GetName() << endl;
@@ -215,7 +218,7 @@ void crossSectionDataFromFile(int signal_definition_int = 0,
   // Macro Utility
   const std::string macro("CrossSectionDataFromFile");
   bool do_truth = false, is_grid = false, do_systematics = true;
-  CCPi::MacroUtil util(signal_definition_int, mc_file_list, data_file_list,
+  CCPi::MacroUtil util(signal_definition_int, params, mc_file_list, data_file_list,
                        plist, do_truth, is_grid, do_systematics);
   util.PrintMacroConfiguration(macro);
 

--- a/xsec/makeCrossSectionMCInputs.C
+++ b/xsec/makeCrossSectionMCInputs.C
@@ -150,6 +150,7 @@ std::vector<Variable*> GetAnalysisVariables(SignalDefinition signal_definition,
   std::vector<Variable*> variables;
   switch (signal_definition) {
     case kOnePi:
+    case kParams:
       variables = make_xsec_mc_inputs::GetOnePiVariables(include_truth_vars);
       break;
     default:
@@ -202,7 +203,7 @@ void LoopAndFillMCXSecInputs(const CCPi::MacroUtil& util,
         //if (universe->GetDouble("mc_incoming") == 12 &&
         //    universe->ShortName() == "cv")
         //  universe->PrintArachneLink();
-        CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe); // call GetWeight
+        CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe, util.m_params); // call GetWeight
 
         //===============
         // FILL TRUTH
@@ -220,7 +221,8 @@ void LoopAndFillMCXSecInputs(const CCPi::MacroUtil& util,
             // fill-in cv_reco_pion_candidate_idxs and cv_is_w_sideband
             cv_passes_cuts =
                 PassesCuts(*universe, cv_reco_pion_candidate_idxs, is_mc,
-                           util.m_signal_definition, cv_is_w_sideband);
+                           util.m_signal_definition, cv_is_w_sideband,
+                           util.m_params);
             checked_cv = true;
           }
 
@@ -265,7 +267,10 @@ void makeCrossSectionMCInputs(int signal_definition_int = 0,
                               bool do_systematics = false,
                               bool do_truth = true, bool is_grid = false,
                               std::string input_file = "",
-                              std::string outfile_name = "") {
+                              std::string outfile_name = "",
+                              double w_exp = 1400., double npi = 1, double pim = 0, double pi0 = 0) {
+  // Initialize params tuple
+  std::vector<double> params{ w_exp, npi, pim, pi0 };
   // INPUT TUPLES
   const bool is_mc = true;
   std::string mc_file_list;
@@ -280,7 +285,7 @@ void makeCrossSectionMCInputs(int signal_definition_int = 0,
   const std::string macro("MCXSecInputs");
   // std::string a_file =
   // "root://fndca1.fnal.gov:1094///pnfs/fnal.gov/usr/minerva/persistent/users/bmesserl/pions//20200713/merged/mc/ME1A/CCNuPionInc_mc_AnaTuple_run00110000_Playlist.root";
-  CCPi::MacroUtil util(signal_definition_int, mc_file_list, plist, do_truth,
+  CCPi::MacroUtil util(signal_definition_int, params, mc_file_list, plist, do_truth,
                        is_grid, do_systematics);
   util.PrintMacroConfiguration(macro);
 

--- a/xsec/plotCrossSectionFromFile.C
+++ b/xsec/plotCrossSectionFromFile.C
@@ -42,7 +42,11 @@ void SetPOT(TFile& fin, CCPi::MacroUtil& util) {
 // Main
 //==============================================================================
 void plotCrossSectionFromFile(int signal_definition_int = 0,
-                              int plot_errors = 1, std::string xsec_inputs = "", std::string data_file_list = "data_list.txt", std::string mc_file_list = "mc_list.txt") {
+                              int plot_errors = 1, std::string xsec_inputs = "",
+                              std::string data_file_list = "data_list.txt", std::string mc_file_list = "mc_list.txt",
+                             double w_exp = 1400., double npi = 1, double pim = 0, double pi0 = 0) {
+  // Initialize params tuple
+  std::vector<double> params{ w_exp, npi, pim, pi0 };
   // Infiles
   TFile fin(xsec_inputs.c_str(), "READ");
   cout << "Reading input from " << fin.GetName() << endl;
@@ -71,7 +75,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   // Macro Utility
   const std::string macro("PlotCrossSectionFromFile");
   bool do_truth = false, is_grid = false, do_systematics = true;
-  CCPi::MacroUtil util(signal_definition_int, mc_file_list, data_file_list,
+  CCPi::MacroUtil util(signal_definition_int, params, mc_file_list, data_file_list,
                        plist, do_truth, is_grid, do_systematics);
   util.PrintMacroConfiguration(macro);
 
@@ -81,7 +85,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   std::string data_file_list_CCPi = data_file_list;
   std::string mc_file_list_CCPi = mc_file_list;
 
-  CCPi::MacroUtil utilCCPi(signal_definition_int, mc_file_list_CCPi,
+  CCPi::MacroUtil utilCCPi(signal_definition_int, params, mc_file_list_CCPi,
                            data_file_list_CCPi, plist, do_truth, is_grid,
                            do_systematics);
   utilCCPi.PrintMacroConfiguration(macro);

--- a/xsec/plotting_functions.h
+++ b/xsec/plotting_functions.h
@@ -415,7 +415,7 @@ void Plot_BGSub(EventSelectionPlotInfo p, std::string outdir = ".",
   assert(p.m_variable->m_hists.m_effnum.hist);
 
   TCanvas canvas("c1", "c1");
-
+  std::cout << "TAG 1";
   // Get Hists
   TH1D* bg_sub_data_w_tot_error =
       new TH1D(p.m_variable->m_hists.m_bg_subbed_data->GetCVHistoWithError());
@@ -423,7 +423,7 @@ void Plot_BGSub(EventSelectionPlotInfo p, std::string outdir = ".",
       p.m_variable->m_hists.m_bg_subbed_data->GetCVHistoWithStatError());
   TH1D* effnum_w_stat_error =
       new TH1D(p.m_variable->m_hists.m_effnum.hist->GetCVHistoWithStatError());
-
+  std::cout << "TAG 2";
   // Log Scale
   if (do_log_scale) {
     canvas.SetLogy();


### PR DESCRIPTION
Added parameters for W cut, NPi cut, Pi- cut, and Pi0 cut. This is activated by setting signal_definition to 4 (kParams). Variable definitions were not altered, so the consequences of having NPi > 1 in signal needs to be taken into account in the future.